### PR TITLE
Correct endianness in send_joint_commands.py example

### DIFF
--- a/examples/send_joint_commands.py
+++ b/examples/send_joint_commands.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 
     # Create the packets and send them to the Bravo
     for i, position in enumerate(desired_positions):
-        packet = Packet(DeviceID(i), PacketID.POSITION, struct.pack(">f", position))
+        packet = Packet(DeviceID(i), PacketID.POSITION, struct.pack("<f", position))
         bravo.send(packet)
 
     # Shutdown the connection


### PR DESCRIPTION
# Checklist

- [X] I have performed a thorough review of my code
- [X] I have sufficiently commented my code
- [X] The implementation follows the project style conventions
- [X] All project unit tests are passing
- [X] If relevant, documentation has been provided or updated to discuss the changes made
- [X] System integration tests were performed successfully

## Changes Made

Blueprint communications are little-endian;  this PR corrects `examples/send_joint_commands.py` to pack the float joint position little-endian.

## Associated Issues

n/a

## Files Changed

`examples/send_joint_commands.py` : Fix endianness in `struct.pack` format string.

## Testing

Tested with Bravo 7 arm (using cut-down version of script which commands a single axis).
