### PR TITLE
Add support for >= Python 3.8

### DIFF
--- a/examples/send_joint_commands.py
+++ b/examples/send_joint_commands.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
 
     # Create the packets and send them to the Bravo
     for i, position in enumerate(desired_positions):
-        packet = Packet(DeviceID(i), PacketID.POSITION, struct.pack("<f", position))
+        packet = Packet(DeviceID(i + 1), PacketID.POSITION, struct.pack("<f", position))
         bravo.send(packet)
 
     # Shutdown the connection

--- a/pybravo/driver/driver.py
+++ b/pybravo/driver/driver.py
@@ -31,6 +31,7 @@ Examples:
         )
     >>> bravo.send(packet)
 """
+from __future__ import annotations
 
 import atexit
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,9 @@ authors = [
   { name = 'Evan Palmer', email='evanp922@gmail.com' },
 ]
 license = {file = 'LICENSE'}
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 dependencies = [
-  "crc>=3.0.1",
+  "crc>=4.2.0",
   "cobs>=1.2.0"
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 license = {file = 'LICENSE'}
 requires-python = '>=3.7'
 dependencies = [
-  "crc>=4.2.0",
+  "crc>=3.0.1",
   "cobs>=1.2.0"
 ]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
   { name = 'Evan Palmer', email='evanp922@gmail.com' },
 ]
 license = {file = 'LICENSE'}
-requires-python = '>=3.10'
+requires-python = '>=3.7'
 dependencies = [
   "crc>=4.2.0",
   "cobs>=1.2.0"


### PR DESCRIPTION
# Checklist

- [X] I have performed a thorough review of my code
- [X] I have sufficiently commented my code
- [X] The implementation follows the project style conventions
- [X] All project unit tests are passing
- [X] If relevant, documentation has been provided or updated to discuss the changes made
- [X] System integration tests were performed successfully

## Changes Made

Change to python version required. Used [vermin](https://github.com/netromdk/vermin) to check for feature compatibility. 

## Associated Issues

N/A

## Files Changed

`pyproject.toml`: Changed the required python version to 3.8 from 3.10.
* Used [vermin](https://github.com/netromdk/vermin) to check the required python version. Minimum required is 3.7. 
* Almost everything we are using to test is 3.9, so instead of needlessly upgrading python version, just downgraded the required version of this package.
* Per @amarburg suggestion, setting the minimum version to be 3.8 (this is because 3.8 is default on 20.04 ubuntu and with ros noetic)

## Testing
Tested using the pytest scripts. 
Have also ran in-person on the Bravo Arm at UW-APL.
Ran example files to check proper functionality.

